### PR TITLE
add linux download method: fcitx5-rime

### DIFF
--- a/blog/source/download/index.md
+++ b/blog/source/download/index.md
@@ -52,6 +52,10 @@ RIME／中州韻輸入法引擎，是一個跨平臺的輸入法算法框架。
 
 *（第三方軟件）* 基於 Fcitx 輸入法框架的 [fcitx-rime](https://github.com/fcitx/fcitx-rime)，由 Fcitx 團隊開發和維護。
 
+## fcitx5-rime
+
+*（第三方軟件）* 基於 Fcitx5 輸入法框架的 [fcitx5-rime](https://github.com/fcitx/fcitx5-rime)，由 Fcitx 團隊開發和維護。
+
 # <a name="android">Android</a>
 
 ## 同文 <small>Tongwen Rime Input Method Editor</small>


### PR DESCRIPTION
ibus-rime最新的包是on Jan 24, 2021
fcitx-rime最新的包是2017年的
都是多年不维护了
fcitx5-rime 最新的[5.1.5](https://github.com/fcitx/fcitx5-rime/releases/tag/5.1.5) 两周前打的tag
官网上的说明太老，我踩坑了，建议更新一下 让大家用fcitx5-rime