### PR TITLE
chore: update brew install command for squirrel

### DIFF
--- a/blog/source/download/index.md
+++ b/blog/source/download/index.md
@@ -33,7 +33,7 @@ RIME／中州韻輸入法引擎，是一個跨平臺的輸入法算法框架。
 
 其他安裝方式：
 
-  * Install via [Homebrew](https://brew.sh): `brew install --cask squirrel`
+  * Install via [Homebrew](https://brew.sh): `brew install squirrel-app`
 
 相關軟件：
 


### PR DESCRIPTION
`squirrel` has been renamed to `squirrel-app` and `--cask` is no longer needed.